### PR TITLE
Add links to website and template instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,9 @@
 OpenAstronomy Packaging Guide
 =============================
 
-A guide to your packaging.
+A `Python Packaging Guide
+<https://packaging-guide.openastronomy.org/en/latest/>`_ that contains
+an embedded `cookiecutter <https://cookiecutter.readthedocs.io/>`_
+template.  Please see also the `instructions for using the template
+<https://packaging-guide.openastronomy.org/en/latest/#using-the-template>`_.
+

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 OpenAstronomy Packaging Guide
 =============================
 
-A `Python Packaging Guide
+The `OpenAstronomy Python Packaging Guide
 <https://packaging-guide.openastronomy.org/en/latest/>`_ that contains
 an embedded `cookiecutter <https://cookiecutter.readthedocs.io/>`_
 template.  Please see also the `instructions for using the template


### PR DESCRIPTION
When I first went to this repository, I found it a bit difficult to know where to begin when using the template.  I added some links to `README.rst` that go to the packaging guide on Read the Docs as well as the instructions on how to use the template.