### PR TITLE
Suppress matplotlib plots on docs build

### DIFF
--- a/docs/docs.rst
+++ b/docs/docs.rst
@@ -88,14 +88,18 @@ as described in :ref:`docstrings`, then this can be automated using the
 `sphinx-automodapi <https://sphinx-automodapi.readthedocs.io>`_
 package. See the documentation of that package for more details, but briefly,
 you will need to add ``'sphinx_automodapi.automodapi'`` to the ``extensions``
-variable in your ``conf.py`` file::
+variable in your ``conf.py`` file:
+
+.. code-block:: python
 
     extensions = ['sphinx_automodapi.automodapi']
 
 In addition, if you use the numpydoc format for your docstrings, as recommended in :ref:`docstrings`,
 you will need to include either ``'numpydoc'`` or ``'sphinx.ext.napoleon'`` in
 the list of ``extensions`` (both packages provide a way to parse numpydoc-style
-docstrings). If you use the numpydoc package, you will need to also include::
+docstrings). If you use the numpydoc package, you will need to also include:
+
+.. code-block:: python
 
     numpydoc_show_class_members = False
 
@@ -110,7 +114,9 @@ configure automated builds (whether for :ref:`ReadTheDocs <readthedocs>`
 or :ref:`tox <tox>`), you should define an ``[options.extras_require]`` section in
 your ``setup.cfg`` file named ``docs`` which lists the dependencies
 required to build the documentation (not including dependencies already
-mentioned in ``install_requires``)::
+mentioned in ``install_requires``):
+
+.. code-block:: cfg
 
     [options.extras_require]
     docs =
@@ -134,7 +140,9 @@ Setting up ReadTheDocs
 documentation with sphinx and will then host it, and is used by many of
 the Scientific Python packages. The easiest way to configure the build
 is to add a file called ``.readthedocs.yml`` to your package, and we
-recommend starting off with::
+recommend starting off with:
+
+.. code-block:: yaml
 
     version: 2
 
@@ -152,3 +160,54 @@ recommend starting off with::
 Once you have added this to your repository, you can then import your
 package into ReadTheDocs as described in `this guide
 <https://docs.readthedocs.io/en/stable/intro/import-guide.html>`_.
+
+.. _plot_directive:
+
+Add plots to your documentation
+-------------------------------
+
+A plot is worth *many* words, and sometimes documentation
+can demonstrate the uses and advantages of using a given
+package much more efficiently than narrative docs. Matplotlib,
+for example, has made this quite straightforward with the
+`plot directive <https://matplotlib.org/stable/api/sphinxext_plot_directive_api.html>`_.
+
+To add a plot to your Sphinx documentation, add the following string to the
+``extensions`` list in your ``docs/conf.py`` file:
+
+.. code-block:: python
+
+    extensions = [
+        ...  # preserve your other extensions here, then add:
+        "matplotlib.sphinxext.plot_directive"
+    ]
+
+To make use of this extension, you will also need to add ``matplotlib`` to your
+``tox.ini`` file:
+
+.. code-block:: ini
+
+    deps =
+       # preserve your other deps here, then add:
+       matplotlib
+
+Now you can add plots to your Sphinx docs by adding a block like
+the following to your narrative docs:
+
+.. code-block:: rst
+
+    Here's a plot:
+
+    .. plot::
+
+        import matplotlib.pyplot as plt
+
+        x, y = [1, 2, 3], [4, 5, 6]
+
+        plt.figure()
+        plt.plot(x, y)
+
+By default, sphinx and matplotlib will render the figure defined by the
+Python code in the ``.. plot::`` block, without the source code. Full documentation
+for the configuration settings for the plot directive can be found in the
+`matplotlib docs <https://matplotlib.org/stable/api/sphinxext_plot_directive_api.html>`_.

--- a/docs/tox.rst
+++ b/docs/tox.rst
@@ -116,6 +116,31 @@ the ``envlist`` is now more complex, the result of this the following:
 with the ``deps`` overridden for ``numpydev`` builds.
 
 
+Environment variables
+#####################
+
+It is often useful to set environment variables within the building and testing
+environment prior to testing. Environment variables can be set within ``tox.ini``
+with:
+
+.. code-block:: ini
+
+    [testenv]
+    # Pass through the following environment variables which may be needed for the CI
+    passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
+
+    # Suppress display of matplotlib plots generated during docs build
+    setenv = MPLBACKEND=agg
+
+The variables listed after ``passenv`` will be preserved from the
+environment that you used to run tox, while the ``setenv`` variables
+are set within the testing environment. In the template, we have set the
+``MPLBACKEND`` variable to the ``agg`` backend, which prevents matplotlib
+from launching interactive plot displays when generating figures from the
+matplotlib plot directive or pytest-mpl. For more on making use of this
+feature, see :ref:`plot_directive`.
+
+
 Building Documentation with tox
 -------------------------------
 

--- a/{{ cookiecutter.package_name }}/tox.ini
+++ b/{{ cookiecutter.package_name }}/tox.ini
@@ -11,6 +11,9 @@ skip_missing_interpreters = True
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
 
+# Suppress display of matplotlib plots generated during docs build
+setenv = MPLBACKEND=agg
+
 # Run the tests in a temporary directory to make sure that we don't import
 # the package from the source tree
 changedir = .tmp/{envname}


### PR DESCRIPTION
This is a version of the improvement in PR astropy/package-template#453. Users attempting to build docs before this PR will find that the matplotlib plot directive renders plots in individual, interactive windows. After this PR, the figures are rendered in the `agg` backend and not in the display.