### PR TITLE
render class-level and __init__-level docstrings

### DIFF
--- a/{{ cookiecutter.package_name }}/docs/conf.py
+++ b/{{ cookiecutter.package_name }}/docs/conf.py
@@ -66,3 +66,12 @@ html_theme = '{{ cookiecutter._sphinx_theme }}'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_static_path = ['_static']
+
+# By default, when rendering docstrings for classes, sphinx.ext.autodoc will 
+# make docs with the class-level docstring and the class-method docstrings, 
+# but not the __init__ docstring, which often contains the parameters to 
+# class constructors across the scientific Python ecosystem. The option below
+# will append the __init__ docstring to the class-level docstring when rendering
+# the docs. For more options, see:
+# https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autoclass_content
+autoclass_content = "both"


### PR DESCRIPTION
Many packages across the Python scientific stack either set the following option in their ``conf.py``

* [sphinx-astropy](https://github.com/astropy/sphinx-astropy/blob/2d2b019c99e02ef38feeb16d28a19610abe499d9/sphinx_astropy/conf/v1.py#L237-L239)

* [matplotlib](https://github.com/matplotlib/matplotlib/blob/312fdb7187c3a26498232e0ec6d36f49d787ed08/doc/conf.py#L606-L608)

or mimic this behavior in their docs ([scipy example](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.InterpolatedUnivariateSpline.html#scipy.interpolate.InterpolatedUnivariateSpline))

Here I set that option in `docs/conf.py` so the documentation that the template, and explain the alternatives in a comment.