### PR TITLE
Release typo fix

### DIFF
--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -82,7 +82,7 @@ Now you have created the sdist to be uploaded to PyPI you can upload it with the
 .. code-block:: console
 
    $ pip install twine
-   $ twine upload sdist/my_package*.tar.gz
+   $ twine upload dist/my_package*.tar.gz
 
 This should ask you for your PyPI account details, and will create your project
 on PyPI if it doesn't already exist.


### PR DESCRIPTION
Currently the docs instruct you to build the source distribution, and then upload it to PyPI via twine. This works fine, and the path to the sdist archive that you create in [this step](https://github.com/OpenAstronomy/packaging-guide/blob/main/docs/releasing.rst#building-source-distributions) is written to the `dist/` dir. 

This PR corrects the path for the twine upload to match the sdist built path under `dist/`.