### PR TITLE
Update passenv for latest tox v4

### DIFF
--- a/{{ cookiecutter.package_name }}/tox.ini
+++ b/{{ cookiecutter.package_name }}/tox.ini
@@ -9,7 +9,7 @@ skip_missing_interpreters = True
 
 [testenv]
 # Pass through the following environment variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
+passenv = HOME, WINDIR, LC_ALL, LC_CTYPE, CC, CI, TRAVIS
 
 # Suppress display of matplotlib plots generated during docs build
 setenv = MPLBACKEND=agg


### PR DESCRIPTION
Since https://github.com/tox-dev/tox/pull/2671, `passenv` variables need to be comma separated (for reasons? 🤷🏻).