### PR TITLE
Bugfix and docs corrections

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,14 +22,12 @@ Using the Template
 
 With this guide is a `cookiecutter <https://cookiecutter.readthedocs.io/>`__
 template which allows you to get started quickly with a package as described in
-this guide. To use this, we recommend you use the `pieceofcake
-<https://pypi.org/project/pieceofcake/>`__ wrapper which gives you more details
-on the questions.
+this guide.
 
 To get started run:
 
 .. code-block:: console
 
    $ pip install cookiecutter
-   $ cookiecutter gh:OpenAstronomy/packaging-guide ./output_directory
+   $ cookiecutter gh:OpenAstronomy/packaging-guide -o ./output_directory
 


### PR DESCRIPTION
The main landing page still says to use `pieceofcake`, but the command was reverted to `cookiecutter`. 

Also, I updated to `cookiecutter==2.1.1` and the output dir path must be specified after `-o <path>`, so I've added that flag.