### PR TITLE
Hotfix pyproject.toml

### DIFF
--- a/{{ cookiecutter.package_name }}/pyproject.toml
+++ b/{{ cookiecutter.package_name }}/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
-name = {{ cookiecutter.module_name }}
-description = {{ cookiecutter.short_description }}
+name = "{{ cookiecutter.module_name }}"
+description = "{{ cookiecutter.short_description }}"
 readme = "README.rst"
 requires-python = ">={{ cookiecutter.minimum_python_version }}"
 license = { file = "licenses/LICENSE.rst", content-type = "text/plain" }
 authors = [
-  { name = {{ cookiecutter.author_name }}, email = {{ cookiecutter.author_email }} },
+  { name = "{{ cookiecutter.author_name }}", email = "{{ cookiecutter.author_email }}" },
 ]
 dependencies = [
   {{ cookiecutter._install_requires }}
@@ -29,7 +29,7 @@ astropy_package_template_example = "{{ cookiecutter.module_name }}.example_mod:m
 {% endif %}
 
 [project.urls]
-repository = {{ cookiecutter.project_url }} 
+repository = "{{ cookiecutter.project_url }}" 
 
 [build-system]
 requires = [
@@ -46,7 +46,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 zip-safe = false
-include-package-date = true
+include-package-data = true
 
 [tool.setuptools.packages.find]
 


### PR DESCRIPTION
Hotfix of `pyproject.toml`, to allow the module to be correctly installed (through `pip install -e .`)

### Changes 

This PR:

- formats the name, description, author name and email, and repository as strings
- fixes the typo in `include-package-date` to `include-package-data`

### Testing

To test the `cookiecutter` template and installation:

```zsh
cookiecutter https://github.com/PaulJWright/packaging-guide.git --checkout hotfix/setup
```

```zsh
(base) ➜  arcaff git:(main) ✗ pip install -e .
Obtaining file:///Users/pwright/work/arcaff
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Installing collected packages: arcaff
  Running setup.py develop for arcaff
Successfully installed arcaff
```

CC zacharyburnett Cadair (sorry, i totally forgot this emails [🤦](https://prod.emojipedia.org/person-facepalming/))

