### PR TITLE
Remove test deprecations

### DIFF
--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/tests/test_example.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/tests/test_example.py
@@ -7,11 +7,3 @@ def test_primes_c():
 def test_primes():
     from ..example_mod import primes
     assert primes(10) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
-
-
-def test_deprecation():
-    import warnings
-    warnings.warn(
-        "This is deprecated, but shouldn't raise an exception, unless "
-        "enable_deprecations_as_exceptions() called from conftest.py",
-        DeprecationWarning)


### PR DESCRIPTION
Lots of packages should be testing that deprecation warnings are converted to errors.