### PR TITLE
Fix tiny shell typo in `tests.rst`

### DIFF
--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -96,7 +96,7 @@ This will then allow contributors to type
 
 .. code-block:: shell
 
-    pip install -e .[test]
+    pip install -e ".[test]"
 
 to install the package in developer/editable mode along with the test
 dependencies.


### PR DESCRIPTION
Single typo correction, just in case this catches people reading through the [Guide](https://packaging-guide.openastronomy.org/en/latest/tests.html). 

From the [pip docs](https://pip.pypa.io/en/stable/cli/pip_install/), 

`pip install .` 

works but not

`pip install .[x]`

Instead it should be 

`pip install ".[x]"`