### PR TITLE
change change_dir

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,7 @@ commands =
 
 [testenv:build_docs]
 description = invoke sphinx-build to build the HTML docs
-change_dir =
-    docs
+change_dir = docs
 deps =
     sphinx
 commands =


### PR DESCRIPTION
Do not ask me why this is an issue but this is 100% reproducible:

```
change_dir = 
    docs
```

gives:

```
Configuration error:
config directory doesn't contain a conf.py file (/home/awilson/src/ripplemapper)
```
It has clearly not changed directory

```
changedir =
    docs
```
  
does change directory and gives:

`build finished with problems, 1 warning.`

Both with:

```
alabaster==0.7.16
Babel==2.15.0
certifi==2024.6.2
charset-normalizer==3.3.2
click==8.1.7
contourpy==1.2.1
coverage==7.5.4
cycler==0.12.1
docutils==0.21.2
exceptiongroup==1.2.1
fonttools==4.53.0
idna==3.7
imageio==2.34.2
imagesize==1.4.1
incremental==22.10.0
iniconfig==2.0.0
Jinja2==3.1.4
kiwisolver==1.4.5
lazy_loader==0.4
MarkupSafe==2.1.5
matplotlib==3.9.0
networkx==3.3
numpy==2.0.0
opencv-python==4.10.0.84
packaging==24.1
pillow==10.3.0
pluggy==1.5.0
Pygments==2.18.0
pyparsing==3.1.2
pytest==8.2.2
pytest-cov==5.0.0
python-dateutil==2.9.0.post0
requests==2.32.3
ripplemapper @ file:///home/awilson/src/ripplemapper/.tox/.tmp/package/1/UNKNOWN-0.0.0.zip
scikit-image==0.24.0
scipy==1.13.1
six==1.16.0
snowballstemmer==2.2.0
Sphinx==7.3.7
sphinx-automodapi==0.17.0
sphinx-copybutton==0.5.2
sphinx-gallery==0.16.0
sphinx-hoverxref==1.4.0
sphinx_changelog==1.5.0
sphinx_design==0.6.0
sphinxcontrib-applehelp==1.0.8
sphinxcontrib-devhelp==1.0.6
sphinxcontrib-htmlhelp==2.0.5
sphinxcontrib-jquery==4.1
sphinxcontrib-jsmath==1.0.1
sphinxcontrib-qthelp==1.0.7
sphinxcontrib-serializinghtml==1.1.10
sphinxext-opengraph==0.9.1
tifffile==2024.6.18
tomli==2.0.1
towncrier==23.11.0
urllib3==2.2.2
```