### PR TITLE
Removes non-existent key for the licence field

### DIFF
--- a/{{ cookiecutter.package_name }}/pyproject.toml
+++ b/{{ cookiecutter.package_name }}/pyproject.toml
@@ -16,7 +16,7 @@ name = "{{ cookiecutter.module_name }}"
 description = "{{ cookiecutter.short_description }}"
 requires-python = ">={{ cookiecutter.minimum_python_version }}"
 readme = { file = "README.rst", content-type = "text/x-rst" }
-license = { file = "licenses/LICENSE.rst", content-type = "text/plain" }
+license = { file = "licenses/LICENSE.rst" }
 {%- if cookiecutter.author_name and cookiecutter.author_email %}
 authors = [
   { name = "{{ cookiecutter.author_name }}", email = "{{ cookiecutter.author_email }}" },


### PR DESCRIPTION
This is not part of the spec: https://packaging.python.org/en/latest/specifications/pyproject-toml/#license