### PR TITLE
MNT: update `setuptools-scm` section in `pyproject.toml` (`write_to option` is deprecated)

### DIFF
--- a/{{ cookiecutter.package_name }}/pyproject.toml
+++ b/{{ cookiecutter.package_name }}/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "setuptools>=62.1",
-  "setuptools_scm[toml]>=6.2",
+  "setuptools_scm[toml]>=8.0.0",
   "wheel",
 {%- if cookiecutter.use_compiled_extensions == 'y' %}
   "extension-helpers",
@@ -59,9 +59,9 @@ exclude = ["{{ cookiecutter.module_name }}._dev*"]
 
 [tool.setuptools_scm]
 {% if cookiecutter.enable_dynamic_dev_versions == 'y' -%}
-write_to = "{{ cookiecutter.module_name }}/_version.py"
+version_file = "{{ cookiecutter.module_name }}/_version.py"
 {%- else -%}
-write_to = "{{ cookiecutter.module_name }}/version.py"
+version_file = "{{ cookiecutter.module_name }}/version.py"
 {%- endif %}
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
see https://setuptools-scm.readthedocs.io/en/latest/config/

I'm also bumping the minimal requirement for setuptools-scm to 8.0 because it's the first version with the replacement option `version_file`.
