### PR TITLE
Replace "Astropy" with "{{ cookiecutter.package_name }}" in BSD-3

### DIFF
--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -60,7 +60,8 @@ def test_licence(license, lfile, cookies):
     with open(base_path / lfile) as fobj:
         expected_content = fobj.readlines()
 
-    assert expected_content[1:] == license_content[1:]
+    assert expected_content[1:11] == license_content[1:11]
+    assert expected_content[12:] == license_content[12:]
 
 
 def test_other_licence(cookies):

--- a/{{ cookiecutter.package_name }}/licenses/BSD3.rst
+++ b/{{ cookiecutter.package_name }}/licenses/BSD3.rst
@@ -9,7 +9,7 @@ are permitted provided that the following conditions are met:
 * Redistributions in binary form must reproduce the above copyright notice, this
   list of conditions and the following disclaimer in the documentation and/or
   other materials provided with the distribution.
-* Neither the name of the Astropy Team nor the names of its contributors may be
+* Neither the name of the {{ cookiecutter.package_name }} team nor the names of its contributors may be
   used to endorse or promote products derived from this software without
   specific prior written permission.
 


### PR DESCRIPTION
This PR updates the BSD-3 license file:
1. replaces "Astropy" with "{{ cookiecutter.package_name }}"
2. replaces "Team" with "team"

I assume point 1. is some leftover that needs to be fixed.

Point 2. is optionally but seems more fitting in my opinion. One could think of further changing

> Neither the name of the {{ cookiecutter.package_name }} team nor the names of its contributors...

to 

> Neither the name of {{ cookiecutter.package_name }} nor the names of its contributors...