### PR TITLE
fixes #82:  added setuptools_scm to fix the issue

### DIFF
--- a/{{ cookiecutter.package_name }}/pyproject.toml
+++ b/{{ cookiecutter.package_name }}/pyproject.toml
@@ -36,7 +36,8 @@ open_astronomy_package_template_example = "{{ cookiecutter.module_name }}.exampl
 test = [
     "pytest",
     "pytest-doctestplus",
-    "pytest-cov"
+    "pytest-cov",
+    "setuptools_scm",
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
To resolve this issue, setuptools_scm is added to the test-optional dependencies in the pyproject.toml file. This ensures that setuptools_scm is installed when the test dependencies are installed, allowing the tests to run without errors.

Changes Made
The pyproject.toml file is updated to include setuptools_scm in the test-optional dependencies:

[project.optional-dependencies]
test = [
    "setuptools_scm",  # Added to resolve ModuleNotFoundError
    "pytest",
    # Other test dependencies
]

Why This Works
setuptools_scm: This package is used for version control and is required by the test environment to access specific files or functionality.

Test Dependencies: Adding setuptools_scm to the test optional dependencies is automatically installed when running pip install -e ".[test]", ensuring that the test environment has all the necessary packages.

Steps to Verify
Install the project and test dependencies:
Commands:  pip install -e .
                     pip install -e ".[test]"

Run the tests:
command:   pytest

Confirm that the tests pass without any ModuleNotFoundError related to setuptools_scm.

Impact
Tests: Tests will now run successfully without requiring manual installation of setuptools_scm.

CI/CD: The CI/CD pipeline will also work correctly, as the test environment will have all the required dependencies.

Future Considerations
Ensure that all required dependencies are explicitly listed in pyproject.toml to avoid similar issues in the future.
Regularly update the dependencies to their latest compatible versions to maintain compatibility and security.

This solution ensures that the test environment is properly configured and that the issue is resolved both locally and in the CI/CD pipeline.

