### PR TITLE
add default build and test workflows and expand toxenvs

### DIFF
--- a/{{ cookiecutter.package_name }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/build.yml
@@ -25,5 +25,3 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v2
 {% endif -%}
       upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
-    secrets:
-       pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}

--- a/{{ cookiecutter.package_name }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: build
+
+on:
+  pull_request:
+  release:
+    types:
+      - released
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+{% if cookiecutter.use_compiled_extensions %}
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v2
+    with:
+      targets: |
+        - cp3*-manylinux_x86_64
+        - cp3*-macosx_x86_64
+        - cp3*-macosx_arm64
+      sdist: true
+{% else %}
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v2
+{% endif %}
+      upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
+    secrets:
+       pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}

--- a/{{ cookiecutter.package_name }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/build.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-{% if cookiecutter.use_compiled_extensions %}
+{%- if cookiecutter.use_compiled_extensions %}
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v2
     with:
       targets: |
@@ -23,7 +23,7 @@ jobs:
       sdist: true
 {% else %}
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v2
-{% endif %}
+{% endif -%}
       upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
     secrets:
        pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}

--- a/{{ cookiecutter.package_name }}/.github/workflows/tests.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
+jobs:
+  test:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
+    with:
+      # run reproducible test environments defined in `tox.ini`
+      envs: |
+        - linux: py311-test-oldestdeps-xdist
+          pytest-results-summary: true
+        - linux: py311-test-xdist
+        - linux: py312-test-xdist
+        - linux: py313-test-xdist
+        - linux: py3-test-xdist
+          pytest-results-summary: true
+        - linux: build-docs

--- a/{{ cookiecutter.package_name }}/.github/workflows/tests.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2

--- a/{{ cookiecutter.package_name }}/.github/workflows/tests_extra.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/tests_extra.yml
@@ -1,0 +1,33 @@
+name: extra tests
+
+on:
+  schedule:
+    # 6am UTC on Mondays
+    - cron: '0 6 * * 1'
+  pull_request:
+    branches:
+      - main
+    types:
+      - synchronize
+      - labeled
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    # only run tests if scheduled, started from a pull request with the `run extra tests` label, or started manually
+    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run extra tests') || github.event_name == 'workflow_dispatch' 
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      # run reproducible test environments defined in `tox.ini`
+      envs: |
+        - macos: py311-oldestdeps-xdist
+        - macos: py311-xdist
+        - macos: py312-xdist
+        - macos: py313-xdist
+        - macos: py3-xdist
+        - linux: py3-devdeps-xdist
+        - macos: py3-devdeps-xdist

--- a/{{ cookiecutter.package_name }}/.github/workflows/tests_extra.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/tests_extra.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     # only run tests if scheduled, started from a pull request with the `run extra tests` label, or started manually
     if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run extra tests') || github.event_name == 'workflow_dispatch'
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       # run reproducible test environments defined in `tox.ini`
       envs: |

--- a/{{ cookiecutter.package_name }}/.github/workflows/tests_extra.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/tests_extra.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test:
     # only run tests if scheduled, started from a pull request with the `run extra tests` label, or started manually
-    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run extra tests') || github.event_name == 'workflow_dispatch' 
+    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run extra tests') || github.event_name == 'workflow_dispatch'
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       # run reproducible test environments defined in `tox.ini`

--- a/{{ cookiecutter.package_name }}/tox.ini
+++ b/{{ cookiecutter.package_name }}/tox.ini
@@ -31,7 +31,6 @@ set_env =
     devdeps: UV_INDEX_STRATEGY = unsafe-any-match
     # Suppress display of matplotlib plots generated during docs build
     MPLBACKEND = agg
-
 # Run the tests in a temporary directory to make sure that we don't import
 # the package from the source tree
 change_dir = .tmp/{envname}
@@ -43,10 +42,12 @@ deps =
     devdeps: -r requirements-dev.txt
     cov: pytest-cov>=4.1.0
     xdist: pytest-xdist
+{% if cookiecutter.use_compiled_extensions %}
 package =
     # necessary so that C extensions are available for import; see https://github.com/spacetelescope/jwst/issues/7386#issuecomment-1344371482
     !pyargs: editable
     pyargs: wheel
+{% endif %}
 commands_pre =
     {list_dependencies_command}
 commands =

--- a/{{ cookiecutter.package_name }}/tox.ini
+++ b/{{ cookiecutter.package_name }}/tox.ini
@@ -42,12 +42,12 @@ deps =
     devdeps: -r requirements-dev.txt
     cov: pytest-cov>=4.1.0
     xdist: pytest-xdist
-{% if cookiecutter.use_compiled_extensions %}
+{%- if cookiecutter.use_compiled_extensions %}
 package =
     # necessary so that C extensions are available for import; see https://github.com/spacetelescope/jwst/issues/7386#issuecomment-1344371482
     !pyargs: editable
     pyargs: wheel
-{% endif %}
+{% endif -%}
 commands_pre =
     {list_dependencies_command}
 commands =

--- a/{{ cookiecutter.package_name }}/tox.ini
+++ b/{{ cookiecutter.package_name }}/tox.ini
@@ -1,25 +1,22 @@
 [tox]
-min_version = 4.0
 envlist =
-    py{310,311,312}-test
-    py10-test-oldestdeps
-    build_docs
+    py{311,312,313,3}-test
+    build-docs
+requires =
+    tox-uv
 
 [testenv]
-# tox environments are constructed with so-called 'factors' (or terms)
-# separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
-# will only take effect if that factor is included in the environment name. To
-# see a list of example environments that can be run, along with a description,
-# run:
-#
-#     tox -l -v
-#
 description =
     run tests
-    oldestdeps: with the oldest supported version of key dependencies
-
-# Pass through the following environment variables which may be needed for the CI
+    oldestdeps: with oldest supported dependency versions
+    devdeps: with latest unreleased dependency versions
+    warnings: treating warnings as errors
+    cov: with coverage
+    xdist: in parallel
 pass_env =
+    HOME
+    TOXENV
+    CODECOV_*
     # A variable to tell tests we are on a CI system
     CI
     # Custom compiler locations (such as ccache)
@@ -29,32 +26,37 @@ pass_env =
     # If the user has set a LC override we should follow it
     # (note LANG is automatically passed through by tox)
     LC_ALL
-
-# Suppress display of matplotlib plots generated during docs build
 set_env =
+    devdeps: UV_INDEX = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    devdeps: UV_INDEX_STRATEGY = unsafe-any-match
+    # Suppress display of matplotlib plots generated during docs build
     MPLBACKEND = agg
 
 # Run the tests in a temporary directory to make sure that we don't import
 # the package from the source tree
 change_dir = .tmp/{envname}
-
-deps =
-    oldestdeps: minimum_dependencies
-    pytest-cov
-
-# The following indicates which extras_require from setup.cfg will be installed
 extras =
     test
-
+uv_resolution =
+    oldestdeps: lowest-direct
+deps =
+    devdeps: -r requirements-dev.txt
+    cov: pytest-cov>=4.1.0
+    xdist: pytest-xdist
+package =
+    # necessary so that C extensions are available for import; see https://github.com/spacetelescope/jwst/issues/7386#issuecomment-1344371482
+    !pyargs: editable
+    pyargs: wheel
 commands_pre =
-    oldestdeps: minimum_dependencies {{ cookiecutter.module_name }} --filename requirements-min.txt
-    oldestdeps: pip install -r requirements-min.txt
-    pip freeze
-
+    {list_dependencies_command}
 commands =
-    pytest --pyargs {{ cookiecutter.module_name }} --cov {{ cookiecutter.module_name }} --cov-report xml:coverage.xml --cov-report term-missing {posargs}
+    pytest \
+    cov: --cov {{ cookiecutter.module_name }} --cov-report xml:coverage.xml --cov-report term-missing \
+    warnings: -W error \
+    xdist: -n auto \
+    {posargs}
 
-[testenv:build_docs]
+[testenv:build-docs]
 description = invoke sphinx-build to build the HTML docs
 change_dir =
     docs


### PR DESCRIPTION
- use OpenAstronomy reusable workflows for building and testing
- use `tox-uv` to resolve `lowest-direct`, instead of `minimum_dependencies`, for `oldestdeps`
- add `devdeps` and `xdist` tox factors