### PR TITLE
add default ReadTheDocs configuration with `graphviz` installed

### DIFF
--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,8 +1,0 @@
-name: rtd311
-channels:
- - conda-forge
- - defaults
-dependencies:
- - python=3.11
- - pip
- - graphviz

--- a/{{ cookiecutter.package_name }}/.readthedocs.yaml
+++ b/{{ cookiecutter.package_name }}/.readthedocs.yaml
@@ -10,6 +10,13 @@ build:
   apt_packages:
     - graphviz
 
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
 sphinx:
   builder: html
   configuration: docs/conf.py


### PR DESCRIPTION
instead of building an environment with `mamba`, we can use `apt` to install `graphviz` by default (if the user needs a `mamba` environment they can update `.readthedocs.yaml` themselves)