### PR TITLE
build templated package against Numpy 2 by default

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,10 +13,9 @@
         "Other"
     ],
     "minimum_python_version": [
-        "3.9",
-        "3.10",
         "3.11",
-        "3.12"
+        "3.12",
+        "3.13"
     ],
     "use_compiled_extensions": "n",
     "enable_dynamic_dev_versions": "n",

--- a/{{ cookiecutter.package_name }}/pyproject.toml
+++ b/{{ cookiecutter.package_name }}/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
   "wheel",
 {%- if cookiecutter.use_compiled_extensions == 'y' %}
   "extension-helpers",
-  "numpy>=1.25",
+  "numpy>=2",
   "cython"
 {% endif -%}
 ]


### PR DESCRIPTION
since Numpy 2 ABI is backwards-compatible with Numpy 1.x in runtime, but not vice versa